### PR TITLE
Add an example to print trust anchors.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ webpki = "0.21"
 webpki-roots = "0"
 ring = "0.16.5"
 untrusted = "0.7.0"
+x509-parser = "0.9.2"
 
 [features]
 default = ["rustls"]

--- a/examples/print-trust-anchors.rs
+++ b/examples/print-trust-anchors.rs
@@ -1,0 +1,29 @@
+// Print the Subject of all extracted trust anchors.
+
+use rustls_native_certs;
+use std::io::{BufRead, Error};
+use x509_parser::prelude::*;
+
+struct Printer {}
+
+impl rustls_native_certs::RootStoreBuilder for Printer {
+    fn load_der(&mut self, der: Vec<u8>) -> Result<(), Error> {
+        let (_, cert) = parse_x509_certificate(&der).unwrap();
+        println!("{}", cert.tbs_certificate.subject);
+        Ok(())
+    }
+    fn load_pem_file(&mut self, rd: &mut dyn BufRead) -> Result<(), Error> {
+        let mut buf = vec![];
+        rd.read_to_end(&mut buf)?;
+        for pem in Pem::iter_from_buffer(&mut buf) {
+            let pem = pem.expect("Reading next PEM block failed");
+            let cert = pem.parse_x509().expect("X.509: decoding DER failed");
+            println!("{}", cert.tbs_certificate.subject);
+        }
+        Ok(())
+    }
+}
+
+fn main() {
+    rustls_native_certs::build_native_certs(&mut Printer {}).unwrap();
+}

--- a/src/rustls.rs
+++ b/src/rustls.rs
@@ -24,7 +24,7 @@ pub type PartialResult<T, E> = Result<T, (Option<T>, E)>;
 pub fn load_native_certs() -> PartialResult<RootCertStore, Error> {
     struct RootCertStoreLoader {
         store: RootCertStore,
-    };
+    }
     impl RootStoreBuilder for RootCertStoreLoader {
         fn load_der(&mut self, der: Vec<u8>) -> Result<(), Error> {
             self.store.add(&rustls::Certificate(der))


### PR DESCRIPTION
Also remove a `;` that was breaking compile for me.