### PR TITLE
Prepare 0.6.1 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-native-certs"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2018"
 authors = ["Joseph Birr-Pixton <jpixton@gmail.com>"]
 license = "Apache-2.0/ISC/MIT"

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ If you'd like to help out, please see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Release history:
 
+* 0.6.1 (2021-10-25):
+  - Allow overrides using `SSL_CERT_FILE` on all platforms.
 * 0.6.0 (2021-10-24):
   - Remove rustls dependency entirely.
 * 0.5.0 (2020-11-22):


### PR DESCRIPTION
Since this is API compatible, might as well get it out now.