### PR TITLE
Make CI work on macOS 11 runners

### DIFF
--- a/integration-tests/macos.sh
+++ b/integration-tests/macos.sh
@@ -33,6 +33,9 @@ test_distrust_existing_root() {
   reset
 }
 
+# https://developer.apple.com/forums/thread/671582?answerId=693632022#693632022
+security authorizationdb write com.apple.trust-settings.admin allow
+
 reset
 test_distrust_existing_root
 printf "\n*** All tests passed ***\n"


### PR DESCRIPTION
Since the macOS integration test appears to be broken, see if we can fix it.

This seems to be due to the [recent switch](https://github.com/actions/virtual-environments/issues/4060) to macOS 11 for the CI environments. Filed https://github.com/actions/virtual-environments/issues/4734 upstream.