### PR TITLE
Bump MSRV to 1.51

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.50.0
+          - 1.51.0
         os: [ubuntu-18.04]
         # but only stable on macos/windows (slower platforms)
         include:


### PR DESCRIPTION
This tracks rustls's new requirement, for resolver=2