### PR TITLE
CI: update workflow actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+- package-ecosystem: cargo
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,10 +32,9 @@ jobs:
           persist-credentials: false
 
       - name: Install ${{ matrix.rust }} toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-          override: true
 
       - name: cargo build (debug; default features)
         run: cargo build
@@ -72,17 +71,11 @@ jobs:
         with:
           persist-credentials: false
       - name: Install rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          override: true
-          default: true
           components: rustfmt
       - name: Check formatting
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check
 
   clippy:
     name: Clippy
@@ -93,13 +86,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          override: true
-          default: true
           components: clippy
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-features -- -D warnings
+      - run: cargo clippy --all-features -- --deny warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,7 +27,7 @@ jobs:
             rust: stable
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
 
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
       - name: Install rust toolchain
@@ -89,7 +89,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
       - name: Install rust toolchain


### PR DESCRIPTION
To address [a pending deprecation](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/), and to remove CI warnings this branch brings the CI improvements that landed on the rustls/rustls repo in https://github.com/rustls/rustls/pull/1214 to this repo.

## CI: configure Dependabot for GitHub actions/crates.
This commit adds Dependabot support to the rustls-native-certs crate to match usage in the other rustls repositories.

Dependabot will monitor both Cargo dependencies and GitHub action workflow dependencies.

## CI: actions/checkout@v2 -> v3.
Does what it says on the tin.

## CI: replace actions-rs w/ dtolnay/rust-toolchain.
This commit replaces the actions-rs/toolchain action with dtolnay/rust-toolchain. The former is [no longer maintained](https://github.com/actions-rs/toolchain/issues/216).

Usages of actions-rs/cargo are replaced with direct invocation of the relevant tooling installed by dtolnay/rust-toolchain.