### PR TITLE
deps: update rustls v0.20.0 -> v0.21.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ webpki = "0.22"
 webpki-roots = "0.22"
 ring = "0.16.5"
 untrusted = "0.7.0" # stick to the version ring depends on for now
-rustls = "0.20"
+rustls = "0.21.0"
 x509-parser = "0.15"
 serial_test = "0.8" # later versions depend on dashmap, which requires a newer MSRV
 


### PR DESCRIPTION
This commit updates rustls-native-certs to use the recently released rustls 0.21.0.

Nothing interesting to report here. It "just works" (modulo flaky smoke tests in CI).