### PR TITLE
docs: recommend `add_parseable_certificates`.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,20 @@
 //!
 //! ```no_run
 //! let mut roots = rustls::RootCertStore::empty();
+//! let root_certs = &rustls_native_certs::load_native_certs()
+//!     .expect("could not load platform certs")
+//!     .iter()
+//!     .map(|c| c.0.clone())
+//!     .collect::<Vec<Vec<u8>>>();
+//!
+//! roots.add_parsable_certificates(root_certs);
+//! ```
+//!
+//! Or, if you're certain your root store contains no potentially malformed
+//! certificates:
+//!
+//! ```no_run
+//! let mut roots = rustls::RootCertStore::empty();
 //! for cert in rustls_native_certs::load_native_certs().expect("could not load platform certs") {
 //!     roots
 //!         .add(&rustls::Certificate(cert.0))


### PR DESCRIPTION
Unfortunately the system root store may contain legacy, malformed certificates. Calling `RootCertStore.add` with these certificates (as previously recommended in the example usage) will error.

In this commit an example using the more lenient `add_parseable_certificates` is offered ahead of the `add` example.

See https://github.com/rustls/rustls/pull/1248 and https://github.com/rustls/rustls/issues/1246 for more information.