### PR TITLE
Prepare 0.6.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-native-certs"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 rust-version = "1.60"
 license = "Apache-2.0 OR ISC OR MIT"

--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ If you'd like to help out, please see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Release history:
 
+* 0.6.3 (2023-06-14)
+  - Bump MSRV to 1.60.
+  - Windows: avoid storing certificates which are currently invalid.
+  - Implement `AsRef<[u8]>` for `Certificate`.
 * 0.6.2 (2022-04-14):
   - Update dependencies.
 * 0.6.1 (2021-10-25):


### PR DESCRIPTION
- [x] Update changelog.
- [x] `cargo update`.
- [x] `cargo outdated`.
- [x] `cargo test --all-features`.
- [x] Update `version` in `Cargo.toml`.
- [x] `cargo publish --dry-run`

I added what I thought was important to the changelog, please advise otherwise.

Should I make the git tag or should it be the one who publishes?