### PR TITLE
Update to pki-types 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,16 +11,16 @@ repository = "https://github.com/ctz/rustls-native-certs"
 categories = ["network-programming", "cryptography"]
 
 [dependencies]
-rustls-pemfile = "=2.0.0-alpha.0"
-pki-types = { package = "rustls-pki-types", version = "0.1" }
+rustls-pemfile = "=2.0.0-alpha.1"
+pki-types = { package = "rustls-pki-types", version = "0.2" }
 
 [dev-dependencies]
 ring = "0.16.5"
-rustls = "=0.22.0-alpha.1"
-rustls-webpki = "=0.102.0-alpha.1"
+rustls = "=0.22.0-alpha.2"
+rustls-webpki = "=0.102.0-alpha.2"
 serial_test = "2"
 untrusted = "0.7.0" # stick to the version ring depends on for now
-webpki-roots = "=0.26.0-alpha.0"
+webpki-roots = "=0.26.0-alpha.1"
 x509-parser = "0.15"
 
 [target.'cfg(windows)'.dependencies]


### PR DESCRIPTION
Updates to the current latest version `pki-types` and corresponding `rustls` ecosystems.