### PR TITLE
Bump version to 0.7.0-alpha.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-native-certs"
-version = "0.7.0-alpha.1"
+version = "0.7.0-alpha.2"
 edition = "2021"
 rust-version = "1.60"
 license = "Apache-2.0 OR ISC OR MIT"


### PR DESCRIPTION
Bumps the version to 0.7.0-alpha.2.