### PR TITLE
Windows: Also load intermediate CAs

### DIFF
--- a/src/windows.rs
+++ b/src/windows.rs
@@ -16,11 +16,13 @@ fn usable_for_rustls(uses: schannel::cert_context::ValidUses) -> bool {
 pub fn load_native_certs() -> Result<Vec<CertificateDer<'static>>, Error> {
     let mut certs = Vec::new();
 
-    let current_user_store = schannel::cert_store::CertStore::open_current_user("ROOT")?;
+    for which in ["ROOT", "CA"] {
+        let current_user_store = schannel::cert_store::CertStore::open_current_user(which)?;
 
-    for cert in current_user_store.certs() {
-        if usable_for_rustls(cert.valid_uses().unwrap()) && cert.is_time_valid().unwrap() {
-            certs.push(CertificateDer::from(cert.to_der().to_vec()));
+        for cert in current_user_store.certs() {
+            if usable_for_rustls(cert.valid_uses().unwrap()) && cert.is_time_valid().unwrap() {
+                certs.push(CertificateDer::from(cert.to_der().to_vec()));
+            }
         }
     }
 


### PR DESCRIPTION
# Load the "CA" `CertStore` location, alongside the "ROOT" location on Windows

## Background

We use `rustls` and `rustls-native-certs` in the QuestDB client.
One of our users (an enterprise) has their own Root CA and Intermediate CA registered with Windows.
When they start our database with TLS certs, the public key cert only contains a single key, rather than a full chain.
When this cert is used for https, browsers like chrome and firefox (with `security.enterprise_roots.enabled=true`) can resolve the chain properly, but our `rustls`/`rustls-native-certs`-based client can't: It can only find the root certificate, but not the intermediate cert.

![WindowsIntermediateCaIssue](https://github.com/rustls/rustls-native-certs/assets/1499096/e82048dd-c9d0-43b7-afcc-7c8ee617cad8)

## The Change

The problem seems to goes away if loading CAs from both the "ROOT" `CertStore` (on my box, finds 50 certs) and the "CA" store (on my box, finds 12 intermediate certificates).

## Disclaimer

For full disclosure, I'd like to state I'm either a TLS nor Windows expert. This has been discovered experimentally rather than through an actual understanding of the `CertStore` API: I don't know if the approach from this PR has any downsides.