### PR TITLE
Check docs in CI, use doc_auto_cfg

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -119,6 +119,23 @@ jobs:
       - name: Check semver
         uses: obi1kenobi/cargo-semver-checks-action@v2
 
+  docs:
+    name: Check for documentation errors
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install rust toolchain
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: cargo doc (rustls; all features)
+        run: cargo doc --locked --all-features --no-deps --document-private-items
+        env:
+          RUSTDOCFLAGS: -Dwarnings
+
   format:
     name: Format
     runs-on: ubuntu-latest

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,9 +8,6 @@
 //! If the SSL_CERT_FILE environment variable is set, certificates (in PEM
 //! format) are read from that file instead.
 //!
-//! [`Certificate`] here is just a marker newtype that denotes a DER-encoded
-//! X.509 certificate encoded as a `Vec<u8>`.
-//!
 //! If you want to load these certificates into a `rustls::RootCertStore`,
 //! you'll likely want to do something like this:
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,9 @@
 //! }
 //! ```
 
+// Enable documentation for all features on docs.rs
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+
 #[cfg(all(unix, not(target_os = "macos")))]
 mod unix;
 #[cfg(all(unix, not(target_os = "macos")))]


### PR DESCRIPTION
Quick follow-up to #85 - I overlooked that we weren't checking cargo docs in CI. This branch fixes one doc error, adds `doc_auto_cfg`, and adds a CI job for checking docs.