### PR TITLE
Prepare 0.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -694,7 +694,7 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "openssl-probe",
  "ring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-native-certs"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 rust-version = "1.60"
 license = "Apache-2.0 OR ISC OR MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,10 +118,10 @@ use pki_types::CertificateDer;
 ///
 /// [c_rehash]: https://www.openssl.org/docs/manmaster/man1/c_rehash.html
 pub fn load_native_certs() -> Result<Vec<CertificateDer<'static>>, Error> {
-    if let Some(certs) = CertPaths::from_env().load()? {
-        return Ok(certs);
-    };
-    platform::load_native_certs()
+    match CertPaths::from_env().load()? {
+        Some(certs) => Ok(certs),
+        None => platform::load_native_certs(),
+    }
 }
 
 /// Certificate paths from `SSL_CERT_FILE` and/or `SSL_CERT_DIR`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,6 +148,11 @@ fn load_certs_from_env() -> Result<Option<Vec<CertificateDer<'static>>>, Error> 
     })
 }
 
+struct CertPaths {
+    file: Option<PathBuf>,
+    dir: Option<PathBuf>,
+}
+
 impl CertPaths {
     fn from_env() -> Self {
         Self {
@@ -171,11 +176,6 @@ impl CertPaths {
 
         Ok(certs)
     }
-}
-
-struct CertPaths {
-    file: Option<PathBuf>,
-    dir: Option<PathBuf>,
 }
 
 fn load_pem_certs(path: &Path) -> Result<Vec<CertificateDer<'static>>, Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,21 +139,23 @@ pub fn load_native_certs() -> Result<Vec<CertificateDer<'static>>, Error> {
 /// subject to the rules outlined above for SSL_CERT_FILE. The directory is not
 /// scanned recursively and may be empty.
 fn load_certs_from_env() -> Result<Option<Vec<CertificateDer<'static>>>, Error> {
-    let paths = CertPaths {
-        file: env::var_os(ENV_CERT_FILE).map(PathBuf::from),
-        dir: env::var_os(ENV_CERT_DIR).map(PathBuf::from),
-    };
-
-    Ok(match &paths {
+    Ok(match CertPaths::from_env() {
         CertPaths {
             file: None,
             dir: None,
         } => None,
-        _ => Some(paths.load()?),
+        paths => Some(paths.load()?),
     })
 }
 
 impl CertPaths {
+    fn from_env() -> Self {
+        Self {
+            file: env::var_os(ENV_CERT_FILE).map(PathBuf::from),
+            dir: env::var_os(ENV_CERT_DIR).map(PathBuf::from),
+        }
+    }
+
     fn load(&self) -> Result<Vec<CertificateDer<'static>>, Error> {
         let mut certs = match &self.file {
             Some(cert_file) => load_pem_certs(cert_file)?,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,19 +173,6 @@ impl CertPaths {
     }
 }
 
-fn load_pem_certs(path: &Path) -> Result<Vec<CertificateDer<'static>>, Error> {
-    let mut f = BufReader::new(File::open(path)?);
-    rustls_pemfile::certs(&mut f)
-        .map(|result| match result {
-            Ok(der) => Ok(der),
-            Err(err) => Err(Error::new(
-                ErrorKind::InvalidData,
-                format!("could not load PEM file {path:?}: {err}"),
-            )),
-        })
-        .collect()
-}
-
 /// Load certificate from certificate directory (what OpenSSL calls CAdir)
 ///
 /// This directory can contain other files and directories. CAfile tends
@@ -221,6 +208,19 @@ fn load_pem_certs_from_dir(dir: &Path) -> Result<Vec<CertificateDer<'static>>, E
         }
     }
     Ok(certs)
+}
+
+fn load_pem_certs(path: &Path) -> Result<Vec<CertificateDer<'static>>, Error> {
+    let mut f = BufReader::new(File::open(path)?);
+    rustls_pemfile::certs(&mut f)
+        .map(|result| match result {
+            Ok(der) => Ok(der),
+            Err(err) => Err(Error::new(
+                ErrorKind::InvalidData,
+                format!("could not load PEM file {path:?}: {err}"),
+            )),
+        })
+        .collect()
 }
 
 /// Check if this is a hash-based file name for a certificate

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,14 +118,10 @@ use pki_types::CertificateDer;
 ///
 /// [c_rehash]: https://www.openssl.org/docs/manmaster/man1/c_rehash.html
 pub fn load_native_certs() -> Result<Vec<CertificateDer<'static>>, Error> {
-    if let Some(certs) = load_certs_from_env()? {
+    if let Some(certs) = CertPaths::from_env().load()? {
         return Ok(certs);
     };
     platform::load_native_certs()
-}
-
-fn load_certs_from_env() -> Result<Option<Vec<CertificateDer<'static>>>, Error> {
-    CertPaths::from_env().load()
 }
 
 /// Certificate paths from `SSL_CERT_FILE` and/or `SSL_CERT_DIR`.

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -11,4 +11,5 @@ pub fn load_native_certs() -> Result<Vec<CertificateDer<'static>>, Error> {
         dir: likely_locations.cert_dir,
     }
     .load()
+    .map(|certs| certs.unwrap_or_default())
 }


### PR DESCRIPTION
## Proposed release notes

* Include certificates from the `SSL_CERT_DIR` environment variable and openssl-probe `ProbeResult::cert_dir` in the set of returned certificates. This should improve results on FreeBSD (in case the `ca_root_nss` package is not installed).

Some follow-up from #109 and a version bump for 0.7.1.