### PR TITLE
Separate online smoke tests from main CI

### DIFF
--- a/.github/workflows/smoke-tests.yaml
+++ b/.github/workflows/smoke-tests.yaml
@@ -1,0 +1,53 @@
+name: smoke-tests
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  schedule:
+    # We run these tests on a daily basis (at a time slightly offset from the
+    # top of the hour), because they rely on external 3rd party services that
+    # can be flaky.
+    - cron: '15 18 * * *'
+
+jobs:
+  smoke-tests:
+    name: Smoke Tests
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        # test a bunch of toolchains on ubuntu
+        rust:
+          - stable
+          - beta
+          - nightly
+        os: [ ubuntu-latest ]
+        # but only stable on macos/windows (slower platforms)
+        include:
+          - os: macos-latest
+            rust: stable
+          - os: windows-latest
+            rust: stable
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install ${{ matrix.rust }} toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+
+      - name: Install NASM for aws-lc-rs on Windows
+        if: runner.os == 'Windows'
+        uses: ilammy/setup-nasm@v1
+
+      - name: Build main crate
+        run: cargo build --locked
+
+      - name: Run smoke tests
+        run: cargo test --locked -- --ignored
+        env:
+          RUST_BACKTRACE: 1

--- a/tests/smoketests.rs
+++ b/tests/smoketests.rs
@@ -64,6 +64,7 @@ fn check_site(domain: &str) -> Result<(), ()> {
 
 #[test]
 #[serial]
+#[ignore]
 fn google() {
     unsafe {
         // SAFETY: safe because of #[serial]
@@ -74,6 +75,7 @@ fn google() {
 
 #[test]
 #[serial]
+#[ignore]
 fn amazon() {
     unsafe {
         // SAFETY: safe because of #[serial]
@@ -84,6 +86,7 @@ fn amazon() {
 
 #[test]
 #[serial]
+#[ignore]
 fn facebook() {
     unsafe {
         // SAFETY: safe because of #[serial]
@@ -94,6 +97,7 @@ fn facebook() {
 
 #[test]
 #[serial]
+#[ignore]
 fn netflix() {
     unsafe {
         // SAFETY: safe because of #[serial]
@@ -104,6 +108,7 @@ fn netflix() {
 
 #[test]
 #[serial]
+#[ignore]
 fn ebay() {
     unsafe {
         // SAFETY: safe because of #[serial]
@@ -114,6 +119,7 @@ fn ebay() {
 
 #[test]
 #[serial]
+#[ignore]
 fn apple() {
     unsafe {
         // SAFETY: safe because of #[serial]
@@ -124,6 +130,7 @@ fn apple() {
 
 #[test]
 #[serial]
+#[ignore]
 fn badssl_with_env() {
     unsafe {
         // SAFETY: safe because of #[serial]
@@ -144,6 +151,7 @@ fn badssl_with_env() {
 
 #[test]
 #[serial]
+#[ignore]
 fn badssl_with_dir_from_env() {
     unsafe {
         // SAFETY: safe because of #[serial]


### PR DESCRIPTION
These tests communicate with 3rd party servers that are outside of our control, and are prone to occasionally flaking.

Instead of running these tests by default this branch marks them as ignored. A new separate, schedule workflow is added to CI that invokes cargo test with the required argument to run the otherwise-ignored smoke tests.