### PR TITLE
Prepare 0.7.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -687,7 +687,7 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "openssl-probe",
  "ring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-native-certs"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 rust-version = "1.60"
 license = "Apache-2.0 OR ISC OR MIT"


### PR DESCRIPTION
Release notes:

- Improve error reporting if we fail when loading certificates from the filesystem.