### PR TITLE
Prefer partial success to failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -687,7 +687,7 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "openssl-probe",
  "ring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-native-certs"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 rust-version = "1.60"
 license = "Apache-2.0 OR ISC OR MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,7 +159,7 @@ impl CertPaths {
 
         let mut certs = match &self.file {
             Some(cert_file) => {
-                load_pem_certs(cert_file).map_err(|err| Self::load_err(cert_file, err))?
+                load_pem_certs(cert_file).map_err(|err| Self::load_err(cert_file, "file", err))?
             }
             None => Vec::new(),
         };
@@ -167,7 +167,7 @@ impl CertPaths {
         if let Some(cert_dir) = &self.dir {
             certs.append(
                 &mut load_pem_certs_from_dir(cert_dir)
-                    .map_err(|err| Self::load_err(cert_dir, err))?,
+                    .map_err(|err| Self::load_err(cert_dir, "dir", err))?,
             );
         }
 
@@ -177,14 +177,10 @@ impl CertPaths {
         Ok(Some(certs))
     }
 
-    fn load_err(path: &Path, err: Error) -> Error {
+    fn load_err(path: &Path, typ: &str, err: Error) -> Error {
         Error::new(
             err.kind(),
-            format!(
-                "could not load certs from {} {}: {err}",
-                if path.is_file() { "file" } else { "dir" },
-                path.display()
-            ),
+            format!("could not load certs from {typ} {}: {err}", path.display()),
         )
     }
 }

--- a/tests/smoketests.rs
+++ b/tests/smoketests.rs
@@ -184,3 +184,53 @@ fn badssl_with_dir_from_env() {
 
     check_site("self-signed.badssl.com").unwrap();
 }
+
+#[test]
+#[serial]
+#[ignore]
+#[cfg(target_os = "linux")]
+fn google_with_dir_but_broken_file() {
+    unsafe {
+        // SAFETY: safe because of #[serial]
+        common::clear_env();
+    }
+
+    env::set_var("SSL_CERT_DIR", "/etc/ssl/certs");
+    env::set_var("SSL_CERT_FILE", "not-exist");
+    check_site("google.com").unwrap();
+}
+
+#[test]
+#[serial]
+#[ignore]
+#[cfg(target_os = "linux")]
+fn google_with_file_but_broken_dir() {
+    unsafe {
+        // SAFETY: safe because of #[serial]
+        common::clear_env();
+    }
+
+    env::set_var("SSL_CERT_DIR", "/not-exist");
+    env::set_var("SSL_CERT_FILE", "/etc/ssl/certs/ca-certificates.crt");
+    check_site("google.com").unwrap();
+}
+
+#[test]
+#[serial]
+#[ignore]
+#[cfg(target_os = "linux")]
+fn nothing_works_with_broken_file_and_dir() {
+    unsafe {
+        // SAFETY: safe because of #[serial]
+        common::clear_env();
+    }
+
+    env::set_var("SSL_CERT_DIR", "/not-exist");
+    env::set_var("SSL_CERT_FILE", "not-exist");
+    assert_eq!(
+        rustls_native_certs::load_native_certs()
+            .unwrap_err()
+            .to_string(),
+        "could not load certs from file not-exist: No such file or directory (os error 2)"
+    );
+}


### PR DESCRIPTION
fixes #124 

Draft release notes:

* If loading certificates from a directory fails, only raise that error if no certificates were successfully loaded from a file. See #124.
  
  In 0.8.0 we plan to alter the API to give the caller full error details, so they can choose the level of success they require; see #128.