### PR TITLE
Yield all the errors

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -167,7 +167,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      - run: cargo clippy --locked --all-features -- --deny warnings
+      - run: cargo clippy --locked --all-features --all-targets -- --deny warnings
 
   clippy-nightly:
     name: Clippy (Nightly)
@@ -181,5 +181,4 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
         with:
           components: clippy
-      - run: cargo clippy --locked --all-features -- --deny warnings
-
+      - run: cargo clippy --locked --all-features --all-targets -- --deny warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -687,7 +687,7 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.7.3"
+version = "0.8.0"
 dependencies = [
  "openssl-probe",
  "ring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-native-certs"
-version = "0.7.3"
+version = "0.8.0"
 edition = "2021"
 rust-version = "1.60"
 license = "Apache-2.0 OR ISC OR MIT"

--- a/examples/print-trust-anchors.rs
+++ b/examples/print-trust-anchors.rs
@@ -4,7 +4,7 @@ use std::error::Error;
 use x509_parser::prelude::*;
 
 fn main() -> Result<(), Box<dyn Error>> {
-    for cert in rustls_native_certs::load_native_certs()? {
+    for cert in rustls_native_certs::load_native_certs().expect("could not load platform certs") {
         match parse_x509_certificate(cert.as_ref()) {
             Ok((_, cert)) => println!("{}", cert.tbs_certificate.subject),
             Err(e) => eprintln!("error parsing certificate: {}", e),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -404,7 +404,7 @@ mod tests {
     fn from_env_bad_dir_perms() {
         // Create a temp dir that we can't read from.
         let temp_dir = tempfile::TempDir::new().unwrap();
-        fs::set_permissions(temp_dir.path(), Permissions::from_mode(0)).unwrap();
+        fs::set_permissions(temp_dir.path(), Permissions::from_mode(0o000)).unwrap();
 
         test_cert_paths_bad_perms(CertPaths {
             file: None,
@@ -420,7 +420,7 @@ mod tests {
         let file_path = temp_dir.path().join("unreadable.pem");
         let cert_file = File::create(&file_path).unwrap();
         cert_file
-            .set_permissions(Permissions::from_mode(0))
+            .set_permissions(Permissions::from_mode(0o000))
             .unwrap();
 
         test_cert_paths_bad_perms(CertPaths {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,15 @@
 // Enable documentation for all features on docs.rs
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
+use std::env;
+use std::ffi::OsStr;
+use std::fs::{self, File};
+use std::io::BufReader;
+use std::io::{Error, ErrorKind};
+use std::path::{Path, PathBuf};
+
+use pki_types::CertificateDer;
+
 #[cfg(all(unix, not(target_os = "macos")))]
 mod unix;
 #[cfg(all(unix, not(target_os = "macos")))]
@@ -35,15 +44,6 @@ use windows as platform;
 mod macos;
 #[cfg(target_os = "macos")]
 use macos as platform;
-
-use std::env;
-use std::ffi::OsStr;
-use std::fs::{self, File};
-use std::io::BufReader;
-use std::io::{Error, ErrorKind};
-use std::path::{Path, PathBuf};
-
-use pki_types::CertificateDer;
 
 /// Load root certificates found in the platform's native certificate store.
 ///

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -1,8 +1,8 @@
-use pki_types::CertificateDer;
-use security_framework::trust_settings::{Domain, TrustSettings, TrustSettingsForCertificate};
-
 use std::collections::HashMap;
 use std::io::{Error, ErrorKind};
+
+use pki_types::CertificateDer;
+use security_framework::trust_settings::{Domain, TrustSettings, TrustSettingsForCertificate};
 
 pub fn load_native_certs() -> Result<Vec<CertificateDer<'static>>, Error> {
     // The various domains are designed to interact like this:

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -1,15 +1,10 @@
-use std::io::Error;
+use crate::{CertPaths, CertificateResult};
 
-use pki_types::CertificateDer;
-
-use crate::CertPaths;
-
-pub fn load_native_certs() -> Result<Vec<CertificateDer<'static>>, Error> {
+pub fn load_native_certs() -> CertificateResult {
     let likely_locations = openssl_probe::probe();
     CertPaths {
         file: likely_locations.cert_file,
         dir: likely_locations.cert_dir,
     }
     .load()
-    .map(|certs| certs.unwrap_or_default())
 }

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -1,8 +1,8 @@
-use crate::CertPaths;
+use std::io::Error;
 
 use pki_types::CertificateDer;
 
-use std::io::Error;
+use crate::CertPaths;
 
 pub fn load_native_certs() -> Result<Vec<CertificateDer<'static>>, Error> {
     let likely_locations = openssl_probe::probe();

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,13 +1,15 @@
 use std::io::Error;
 
 use pki_types::CertificateDer;
+use schannel::cert_context::ValidUses;
+use schannel::cert_store::CertStore;
 
 static PKIX_SERVER_AUTH: &str = "1.3.6.1.5.5.7.3.1";
 
-fn usable_for_rustls(uses: schannel::cert_context::ValidUses) -> bool {
+fn usable_for_rustls(uses: ValidUses) -> bool {
     match uses {
-        schannel::cert_context::ValidUses::All => true,
-        schannel::cert_context::ValidUses::Oids(strs) => strs
+        ValidUses::All => true,
+        ValidUses::Oids(strs) => strs
             .iter()
             .any(|x| x == PKIX_SERVER_AUTH),
     }
@@ -16,7 +18,7 @@ fn usable_for_rustls(uses: schannel::cert_context::ValidUses) -> bool {
 pub fn load_native_certs() -> Result<Vec<CertificateDer<'static>>, Error> {
     let mut certs = Vec::new();
 
-    let current_user_store = schannel::cert_store::CertStore::open_current_user("ROOT")?;
+    let current_user_store = CertStore::open_current_user("ROOT")?;
 
     for cert in current_user_store.certs() {
         if usable_for_rustls(cert.valid_uses().unwrap()) && cert.is_time_valid().unwrap() {

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,6 +1,6 @@
-use pki_types::CertificateDer;
-
 use std::io::Error;
+
+use pki_types::CertificateDer;
 
 static PKIX_SERVER_AUTH: &str = "1.3.6.1.5.5.7.3.1";
 

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -4,17 +4,6 @@ use pki_types::CertificateDer;
 use schannel::cert_context::ValidUses;
 use schannel::cert_store::CertStore;
 
-static PKIX_SERVER_AUTH: &str = "1.3.6.1.5.5.7.3.1";
-
-fn usable_for_rustls(uses: ValidUses) -> bool {
-    match uses {
-        ValidUses::All => true,
-        ValidUses::Oids(strs) => strs
-            .iter()
-            .any(|x| x == PKIX_SERVER_AUTH),
-    }
-}
-
 pub fn load_native_certs() -> Result<Vec<CertificateDer<'static>>, Error> {
     let mut certs = Vec::new();
 
@@ -28,3 +17,14 @@ pub fn load_native_certs() -> Result<Vec<CertificateDer<'static>>, Error> {
 
     Ok(certs)
 }
+
+fn usable_for_rustls(uses: ValidUses) -> bool {
+    match uses {
+        ValidUses::All => true,
+        ValidUses::Oids(strs) => strs
+            .iter()
+            .any(|x| x == PKIX_SERVER_AUTH),
+    }
+}
+
+static PKIX_SERVER_AUTH: &str = "1.3.6.1.5.5.7.3.1";

--- a/tests/compare_mozilla.rs
+++ b/tests/compare_mozilla.rs
@@ -67,7 +67,7 @@ fn test_does_not_have_many_roots_unknown_by_mozilla() {
     let mut missing_in_moz_roots = 0;
 
     for cert in &native {
-        let cert = anchor_from_trusted_cert(&cert).unwrap();
+        let cert = anchor_from_trusted_cert(cert).unwrap();
         if let Some(moz) = mozilla.get(cert.subject_public_key_info.as_ref()) {
             assert_eq!(cert.subject, moz.subject, "subjects differ for public key");
         } else {
@@ -103,7 +103,7 @@ fn test_contains_most_roots_known_by_mozilla() {
 
     let mut native_map = HashMap::new();
     for anchor in &native {
-        let cert = anchor_from_trusted_cert(&anchor).unwrap();
+        let cert = anchor_from_trusted_cert(anchor).unwrap();
         let spki = cert.subject_public_key_info.as_ref();
         native_map.insert(spki.to_owned(), anchor);
     }
@@ -111,10 +111,7 @@ fn test_contains_most_roots_known_by_mozilla() {
     let mut missing_in_native_roots = 0;
     let mozilla = webpki_roots::TLS_SERVER_ROOTS;
     for cert in mozilla {
-        if native_map
-            .get(cert.subject_public_key_info.as_ref())
-            .is_none()
-        {
+        if !native_map.contains_key(cert.subject_public_key_info.as_ref()) {
             println!(
                 "Mozilla anchor {:?} is missing from native set",
                 stringify_x500name(&cert.subject)
@@ -152,7 +149,7 @@ fn util_list_certs() {
     let native = rustls_native_certs::load_native_certs().unwrap();
 
     for (i, cert) in native.iter().enumerate() {
-        let cert = anchor_from_trusted_cert(&cert).unwrap();
+        let cert = anchor_from_trusted_cert(cert).unwrap();
         println!("cert[{i}] = {}", stringify_x500name(&cert.subject));
     }
 }

--- a/tests/smoketests.rs
+++ b/tests/smoketests.rs
@@ -229,7 +229,9 @@ fn nothing_works_with_broken_file_and_dir() {
     env::set_var("SSL_CERT_FILE", "not-exist");
     assert_eq!(
         rustls_native_certs::load_native_certs()
-            .unwrap_err()
+            .errors
+            .first()
+            .unwrap()
             .to_string(),
         "could not load certs from file not-exist: No such file or directory (os error 2)"
     );


### PR DESCRIPTION
Alternative to #126 that is a bit more principled maybe?

Release notes:

* `load_native_certs()` now returns a `CertificateResult` value containing all the certificates that were successfully found as well as any errors encountered. Changes made in 0.7.1 in order to find certificates in more locations resulted in new errors in scenarios that previously worked for most users. This change allows callers to determine the error handling strategy most appropriate to their application.