### PR TITLE
fix load_native_certs() error return, fix smoke tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,7 +119,7 @@ use macos as platform;
 /// [c_rehash]: https://www.openssl.org/docs/manmaster/man1/c_rehash.html
 pub fn load_native_certs() -> CertificateResult {
     match CertPaths::from_env().load() {
-        out if !out.certs.is_empty() => out,
+        out if !out.certs.is_empty() || !out.errors.is_empty() => out,
         _ => platform::load_native_certs(),
     }
 }


### PR DESCRIPTION
I noticed since https://github.com/rustls/rustls-native-certs/pull/128 the `smoke-tests` daily CI job has been failing ([exemplar](https://github.com/rustls/rustls-native-certs/actions/runs/10707466498)).

This branch updates the API to not swallow errors produced when no certs were found, and fixes the broken smoke tests. Doing this required a bit of rejigging to make asserting error conditions _and_ using found certs possible.

Here's [a demo run](https://github.com/cpu/rustls-native-certs/actions/runs/10722412557) of the `smoke-tests` workflow passing after this update.