### PR TITLE
Clarify environment path handling code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,9 +118,10 @@ use macos as platform;
 ///
 /// [c_rehash]: https://www.openssl.org/docs/manmaster/man1/c_rehash.html
 pub fn load_native_certs() -> CertificateResult {
-    match CertPaths::from_env().load() {
-        out if !out.certs.is_empty() || !out.errors.is_empty() => out,
-        _ => platform::load_native_certs(),
+    let paths = CertPaths::from_env();
+    match (&paths.dir, &paths.file) {
+        (Some(_), _) | (_, Some(_)) => paths.load(),
+        (None, None) => platform::load_native_certs(),
     }
 }
 


### PR DESCRIPTION
Current documentation:

```
/// If **either** (or **both**) are set, certificates are only loaded from
/// the locations specified via environment variables and not the platform-
/// native certificate store.
```

This seems like a clearer way of expressing that logic.