### PR TITLE
ci: time out tests after 15 minutes

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,6 +14,7 @@ jobs:
   build:
     name: Build+test
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Harm reduction for #179 

15 minutes is about 3 times longer than this job takes on windows -- hopefully that is sufficient headroom to avoid this becoming annoying in the future.