### PR TITLE
`track_caller` for `CertificateResult::expect()` etc.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -702,7 +702,7 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "openssl-probe",
  "ring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-native-certs"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 rust-version = "1.71"
 license = "Apache-2.0 OR ISC OR MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,6 +136,7 @@ pub struct CertificateResult {
 
 impl CertificateResult {
     /// Return the found certificates if no error occurred, otherwise panic.
+    #[track_caller]
     pub fn expect(self, msg: &str) -> Vec<CertificateDer<'static>> {
         match self.errors.is_empty() {
             true => self.certs,
@@ -144,6 +145,7 @@ impl CertificateResult {
     }
 
     /// Return the found certificates if no error occurred, otherwise panic.
+    #[track_caller]
     pub fn unwrap(self) -> Vec<CertificateDer<'static>> {
         match self.errors.is_empty() {
             true => self.certs,


### PR DESCRIPTION
This PR attempts to improve the error reporting in #185 by reporting the caller of `expect()`/`unwrap()` it its panics, rather than the line in src/lib.rs.