### PR TITLE
Ignore empty entries in SSL_CERT_DIR

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,7 +203,9 @@ impl CertPaths {
             //
             // See <https://docs.openssl.org/3.5/man1/openssl-rehash/#options>
             dirs: match env::var_os(ENV_CERT_DIR) {
-                Some(dirs) => env::split_paths(&dirs).collect(),
+                Some(dirs) => env::split_paths(&dirs)
+                    .filter(|p| !p.as_os_str().is_empty())
+                    .collect(),
                 None => Vec::new(),
             },
         }


### PR DESCRIPTION
A leading or trailing separator (e.g. `:/etc/ssl/certs`) produces an empty path component via `env::split_paths`, which then causes a spurious ENOENT warning when `fs::read_dir("")` is called. Filter out empty components before collecting so they are silently skipped.

Fixes #241